### PR TITLE
Docker enhancements

### DIFF
--- a/webapp/docker/image/Dockerfile
+++ b/webapp/docker/image/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /home/simi
 
 RUN chown -R 1001:0 . && \
     chmod -R g+rw .
-COPY tmp/app.jar /home/simi
-COPY uber-jar-logback.xml /home/simi
+COPY tmp/app.jar .
+COPY uber-jar-logback.xml .
 RUN ls -la .
 
 USER 1001


### PR DESCRIPTION
Ich habe Simi lokal zum Laufen zu bringen versucht. Als Nebenprodukt sind folgende beiden Verbesserungen am Image herausgekommen:
* CMD in der _Exec Form_ schreiben: So stoppt das Image schneller
* File-Mode und -Ownership nach dem COPY nicht mehr ändern: So wird das Image ca. 100MB kleiner